### PR TITLE
Switch throttle to debounce to fix bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,14 @@ Follow these steps to get started:
 
 1. [Install](#install)
 2. [Import](#import)
-4. [Review Options](#options)
+3. [Review Options](#options)
 
 **Note**: It is required that you use a css reset that clears user agent stylesheet margin/padding.
 See here for an [example](https://meyerweb.com/eric/tools/css/reset/).
 
 ### Install
 
-Using NPM, install Heads-up, and save it to your `package.json` dependencies.
-
-```bash
-$ npm install headsup.js --save
-```
+Install this repo as a dependency, or reference the `headsup.js` script file.
 
 ### Import
 
@@ -40,6 +36,7 @@ All options are optional, and come with defaults. The defaults are shown below:
 ```es6
 headsUp({
   selector: 'header',
+  debounce: false,
   hiddenHeaderClass = 'js-header-hidden'
 })
 ```
@@ -47,6 +44,7 @@ headsUp({
 Explanation of each option follows:
 
 * [selector](#selector)
+* [debounce](#debounce)
 * [hiddenHeaderClass](#hiddenHeaderClass)
 
 ### selector
@@ -56,6 +54,19 @@ Any CSS selector that targets to your header element.
 ```es6
 headsUp({
   target: '#header'
+})
+```
+
+### debounce
+
+When the user scrolls, a function is called to check whether it is necessary to hide or reveal the header. Specify the amount of time between function calls with the debounce option, in milliseconds. This may help with performance.
+
+```es6
+
+// will wait 100ms after each function call
+
+headsUp({
+  debounce: 100
 })
 ```
 

--- a/src/headsup.js
+++ b/src/headsup.js
@@ -1,5 +1,6 @@
 export default ({
   selector = 'header',
+  debounce = false,
   hiddenHeaderClass = 'js-header-hidden'
 } = {}) => {
   let show = true; // Initial boolean value
@@ -46,15 +47,21 @@ export default ({
     prev = current;
   };
 
-  let lastCalled = 0;
+  const debounceFunc = wait => {
+    if (!wait) return handleScroll
 
-  // ignore scroll events within 100ms of the previous event
-  window.addEventListener('scroll', () => {
-    const now = new Date().getTime();
-    if (now - lastCalled < 100) return;
-    lastCalled = now;
-    handleScroll();
-  });
+    let timeout = null
+    return () => {
+      if (!timeout) {
+        timeout = setTimeout(() => {
+          handleScroll()
+          timeout = null
+        }, wait)
+      }
+    }
+  }
+
+  window.addEventListener('scroll', debounceFunc(debounce));
 
   const disable = () => (enabled = false);
   const enable = () => (enabled = true);


### PR DESCRIPTION
Also updates readme

---

I had incorrectly suggested we switch the debounce to a throttle. 

The throttle can lead to problems where the last throttled event doesn't match up right with the last user event. (e.g. if you scroll down and up real fast, the menu should show, but the last unthrottled event may have been scrolling down which hides the menu.)

Debouncing avoids this, since the last event's function will always get run.